### PR TITLE
Fix shader no longer working in Compatibility Render mode due to bug with TIME builtin.

### DIFF
--- a/addons/sky_3d/shaders/SkyMaterial.gdshader
+++ b/addons/sky_3d/shaders/SkyMaterial.gdshader
@@ -101,6 +101,9 @@ group_uniforms Transform_Matrices;
 uniform mat3 _moon_matrix; // Set externally via GDScript.
 uniform mat3 _deep_space_matrix; // Set externally via GDScript for star map rotation.
 
+group_uniforms Miscellaneous;
+uniform float _time; // For updating/pausing cloud movement and to work around TIME not working in Compatibility Renderer.
+
 
 const int kCUMULUS_CLOUDS_STEP = 10;
 const float k3PI8 = 3.0 / (8.0 * PI);
@@ -265,7 +268,7 @@ vec3 atmosphericScattering(float sr, float sm, vec2 mu, vec3 mult) {
 // Clouds
 //------------------------------------------------------------------------------
 float noiseClouds(vec2 coords, vec2 offset) {
-	float speed = TIME * _clouds_speed * .5; // .5 matches cumulus clouds
+	float speed = _time * _clouds_speed * .5; // .5 matches cumulus clouds
 	vec2 wind = offset * speed;
 	vec2 wind2 = (offset + offset) * speed;
 	float a = textureLod(_clouds_texture, coords.xy * _clouds_uv - wind, 0.0).r;
@@ -416,7 +419,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	deepSpace.rgb += deepSpaceBackground.rgb * moonMask + moon_output;
 
 	// Stars Field
-	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (TIME * _stars_scintillation_speed), 0.0).r;
+	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (_time * _stars_scintillation_speed), 0.0).r;
 	starsScintillation = mix(1.0, starsScintillation * 1.5, _stars_scintillation);
 
 	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb * _stars_field_color.rgb;
@@ -438,7 +441,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	}
 	
 	if (_cumulus_clouds_visible) {
-		vec4 cumulusClouds = renderCloudsCumulus(vec3(0.0), cloudsPos, TIME, angle_mult.z, sunPosition, moonPosition);
+		vec4 cumulusClouds = renderCloudsCumulus(vec3(0.0), cloudsPos, _time, angle_mult.z, sunPosition, moonPosition);
 		cumulusClouds.a = saturate(cumulusClouds.a);
 		cumulusClouds.rgb *= mix(mix(_cumulus_clouds_day_color.rgb, _cumulus_clouds_horizon_light_color.rgb, angle_mult.x), 
 			_cumulus_clouds_night_color.rgb, angle_mult.w);

--- a/addons/sky_3d/src/Sky3D.gd
+++ b/addons/sky_3d/src/Sky3D.gd
@@ -520,6 +520,7 @@ const GROUND_COLOR_P: String = "_ground_color"
 const NOISE_TEX: String = "_noise_tex"
 const HORIZON_LEVEL: String = "_horizon_level"
 const REFLECTED_ENERGY: String = "_reflected_energy"
+const SKY_TIME: String = "_time"
 
 # Atmosphere
 const ATM_DARKNESS_P: String = "_atm_darkness"

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -357,6 +357,8 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0) )
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0,  (180.0 - __local_sideral_time * TOD_Math.RAD_TO_DEG) * TOD_Math.DEG_TO_RAD)) 
 				__dome.deep_space_quat = x * y
+				
+	__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
 
 
 func __compute_simple_sun_coords() -> void:

--- a/demo/Sky3DDemo.tscn
+++ b/demo/Sky3DDemo.tscn
@@ -77,11 +77,13 @@ shader_parameter/_cumulus_clouds_horizon_light_color = Color(0.98, 0.43, 0.15, 1
 shader_parameter/_cumulus_clouds_night_color = Color(0.090196, 0.094118, 0.129412, 1)
 shader_parameter/_cumulus_clouds_partial_mie_phase = Vector3(0.957564, 1.04244, 0.412)
 shader_parameter/_cumulus_clouds_mie_intensity = 1.0
-shader_parameter/_moon_matrix = Basis(-7.45058e-09, -0.987234, -0.159276, -0.470221, -0.140569, 0.871282, -0.882548, 0.074895, -0.464219)
+shader_parameter/_moon_matrix = Basis(0, -0.989426, -0.145041, -0.51637, -0.124208, 0.84731, -0.856366, 0.074895, -0.51091)
 shader_parameter/_deep_space_matrix = Basis(0.886499, 0.462731, -2.4097e-08, 0.127546, -0.244353, -0.961262, -0.444806, 0.852157, -0.275638)
+shader_parameter/_time = 30.007
 
 [sub_resource type="Sky" id="Sky_0j4pb"]
 sky_material = SubResource("ShaderMaterial_v8wrf")
+process_mode = 3
 
 [sub_resource type="Environment" id="Environment_1g8sw"]
 background_mode = 2
@@ -106,7 +108,7 @@ far = 8192.0
 [node name="ReflectionProbe" type="ReflectionProbe" parent="."]
 update_mode = 1
 size = Vector3(2000, 2000, 2000)
-cull_mask = 4
+cull_mask = 5
 
 [node name="Sky3D" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_1g8sw")


### PR DESCRIPTION
- Added a `_time` uniform to the sky shader, replaced all instances of the `TIME` builtin, and set up the TimeOfDay script to update this property. This allows the shader to function in the Compatibility Renderer. This also has the effect of the clouds now pausing movement when time is disabled. Known issues:
  - Because this depends on TimeOfDay's update process which uses `Time.get_ticks_msec()`, clouds will appear to "jump" when editor or game time is reenabled if enough time has passed.
  - Cloud movement does not look as smooth on account of the default update interval. This can be remedied by setting the update interval a bit lower.
- Set the Sky's process mode to real time. Previously this was being automatically set to real time internally since the TIME builtin was being used. Without this, there is a very noticeable flickering that occurs on the ground and updates to the radiance cubemap causing artifacts.
- Fixed the Reflection Probe not culling the same layer as the lights. The ground is now properly lit over the course of the day and night.