### PR TITLE
Fixed moon projection not updating when date/time is modified.

### DIFF
--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -363,6 +363,7 @@ func __update_celestial_coords() -> void:
 	
 	if _is_compatibility_mode:
 		__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
+	__dome.update_moon_coords()
 
 
 func __compute_simple_sun_coords() -> void:


### PR DESCRIPTION
- Moon texture projection now updates when the date/time properties on TimeOfDay in the inspector are modified and will maintain its "rotation".
  - Caveat: If the rotation of the moon directional light is modified manually or through code for some reason this will result in the moon's transform matrix not being updated until `SkyDome.update_moon_coords()` is called and will cause the projection to be mapped/rotated incorrectly.