### PR TITLE
Star map alignment and better rotation.

### DIFF
--- a/addons/sky_3d/shaders/SkyMaterial.gdshader
+++ b/addons/sky_3d/shaders/SkyMaterial.gdshader
@@ -58,9 +58,22 @@ uniform vec4 _background_color: source_color = vec4(0.71, 0.71, 0.71, 0.855);
 group_uniforms Starfield;
 uniform vec4 _stars_field_color: source_color = vec4(1.0);
 uniform sampler2D _stars_field_texture: source_color;
+uniform vec3 _sky_alignment = vec3(2.6555, -0.23935, 0.4505);
+uniform float _sky_rotation = 0.0; // For simulating Earth rotation.
+uniform float _sky_tilt = 0.0; // For tilting the sky according to observer latitude in radians. (90° - latitude)
 uniform float _stars_scintillation = 0.75;
 uniform float _stars_scintillation_speed = 0.01;
 uniform sampler2D _noise_tex: source_color;
+
+/* Sky alignment values for a star map that is in galactic coordinates. Works for most star maps.
+X: 2.6555
+Y: -0.23935
+Z: 0.4505
+
+These alignment values are consistent with a sky view from the North Pole (latitude zero)
+at midnight. The positions of Polaris, Vega, Rigel, and Alpha Centauri confirmed
+through various sources and calculations.
+*/
 
 // Clouds
 group_uniforms Clouds;
@@ -136,11 +149,36 @@ vec3 tonemapPhoto(vec3 color, float exposure, float level){
 }
 
 
+// Provides a transformation matrix when passed a vec3.
+mat3 rotationMatrix(vec3 r) {
+    float c1 = cos(r.x), s1 = sin(r.x);
+    float c2 = cos(r.y), s2 = sin(r.y);
+    float c3 = cos(r.z), s3 = sin(r.z);
+
+    mat3 rotX = mat3(
+        vec3(1.0, 0.0, 0.0),
+        vec3(0.0, c1, -s1),
+        vec3(0.0, s1, c1)
+    );
+
+    mat3 rotY = mat3(
+        vec3(c2, 0.0, s2),
+        vec3(0.0, 1.0, 0.0),
+        vec3(-s2, 0.0, c2)
+    );
+
+    mat3 rotZ = mat3(
+        vec3(c3, -s3, 0.0),
+        vec3(s3, c3, 0.0),
+        vec3(0.0, 0.0, 1.0)
+    );
+
+    return rotZ * rotY * rotX; // Combine rotations in ZYX order
+}
+
+
 vec2 equirectUV(vec3 norm) {
-	vec2 ret;
-	ret.x = (atan(norm.x, norm.z) + PI) * (1.0 / TAU);
-	ret.y = acos(norm.y) * (1.0/PI);
-	return ret;
+	return vec2((atan(norm.y, norm.x) + PI) / TAU, acos(norm.z) / -PI);
 }
 
 
@@ -415,7 +453,21 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	float moonMask = (1.0 - moon_mask);
 
 	vec3 deepSpace = vec3(0.0);
-	vec2 deepSpaceUV = equirectUV(normalize(deep_space_coords));
+	
+	// Tilt the sky along the X-axis.
+	mat3 tilt = rotationMatrix(vec3(_sky_tilt, 0.0, 0.0));
+
+    // Rotation around Y-axis. For simulating Earth's rotation.
+    mat3 rotation = rotationMatrix(vec3(0.0, _sky_rotation, 0.0));
+
+    // Initial XYZ rotation for alignment.
+    mat3 alignment_xyz = rotationMatrix(_sky_alignment);
+
+	// Combine everything together to get the desired alignment.
+	vec3 final_alignment = normalize(alignment_xyz * rotation * tilt * worldPos);
+	
+	// Now generate UV coordinates for the texture.
+	vec2 deepSpaceUV = equirectUV(normalize(final_alignment));
 
 	// Background
 	vec3 deepSpaceBackground = textureLod(_background_texture, deepSpaceUV, 0.0).rgb;
@@ -427,7 +479,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (time * _stars_scintillation_speed), 0.0).r;
 	starsScintillation = mix(1.0, starsScintillation * 1.5, _stars_scintillation);
 
-	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb * _stars_field_color.rgb;
+	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb;// * _stars_field_color.rgb;
 	starsField = saturateRGB(mix(starsField.rgb, starsField.rgb * starsScintillation, _stars_scintillation));
 	starsField = saturateRGB(starsField.rgb);
 	//deepSpace.rgb -= saturate(starsField.r * 10.0);

--- a/addons/sky_3d/src/Sky3D.gd
+++ b/addons/sky_3d/src/Sky3D.gd
@@ -560,6 +560,9 @@ const MOON_TEXTURE_P: String = "_moon_texture"
 
 # Deep Space
 const DEEP_SPACE_MATRIX_P: String = "_deep_space_matrix"
+const SKY_ALIGNMENT: String = "_sky_alignment"
+const SKY_ROTATION: String = "_sky_rotation"
+const SKY_TILT: String = "_sky_tilt"
 const BG_COL_P: String = "_background_color"
 const BG_TEXTURE_P: String = "_background_texture"
 const STARS_COLOR_P: String = "_stars_field_color"

--- a/addons/sky_3d/src/Skydome.gd
+++ b/addons/sky_3d/src/Skydome.gd
@@ -990,7 +990,8 @@ func update_moon_light_path() -> void:
 #####################
 
 @export_group("Deep Space")
-@export var deep_space_euler: Vector3 = Vector3(0, 0, 0.0): set = set_deep_space_euler
+var deep_space_euler: Vector3 = Vector3(0, 0, 0.0): set = set_deep_space_euler # DEPRECATED
+@export var starmap_alignment: Vector3 = Vector3(2.6555, -0.23935, 0.4505): set = set_starmap_alignment # Default values work for most star maps in galactic coordinate format.
 @export var background_color: Color = Color(0.709804, 0.709804, 0.709804, 0.854902): set = set_background_color
 @export var background_texture: Texture2D = Sky3D._background_texture: set = _set_background_texture
 @export var stars_field_color: Color = Color.WHITE: set = set_stars_field_color
@@ -1000,6 +1001,12 @@ func update_moon_light_path() -> void:
 
 var deep_space_quat: Quaternion = Quaternion.IDENTITY: set = set_deep_space_quat
 var __deep_space_basis: Basis
+
+
+func set_starmap_alignment(value: Vector3) -> void:
+	starmap_alignment = value
+	if sky_material:
+		sky_material.set_shader_parameter(Sky3D.SKY_ALIGNMENT, value)
 
 
 func set_deep_space_euler(value: Vector3) -> void:

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -346,6 +346,7 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0))
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0, __sun_coords.y * TOD_Math.DEG_TO_RAD))
 				__dome.deep_space_quat = x * y
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_TILT, deg_to_rad(90 - latitude))
 		
 		CelestialCalculationsMode.Realistic:
 			__compute_realistic_sun_coords()
@@ -360,10 +361,12 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0) )
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0,  (180.0 - __local_sideral_time * TOD_Math.RAD_TO_DEG) * TOD_Math.DEG_TO_RAD)) 
 				__dome.deep_space_quat = x * y
-	
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_TILT, deg_to_rad(90 - latitude))
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_ROTATION, __local_sideral_time)
+				
+	__dome.update_moon_coords()
 	if _is_compatibility_mode:
 		__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
-	__dome.update_moon_coords()
 
 
 func __compute_simple_sun_coords() -> void:


### PR DESCRIPTION
- Introduced new properties into the shader and GDScript to allow for alignment of star maps. The provided default values work for most star maps in galactic coordinates format and should require little to no adjustment.
  - To-do: Rework the alignment to be more intuitive. Currently it is quite fiddly.
- Introduced properties to the shader and GDScript to directly control sky tilt and rotation for a more intuitive experience.
- Time of day now directly modifies the new sky rotation property and creates a more realistic sky simulation at any latitude. Latitude, Longitude, and UTC settings will also tilt and rotate the sky as expected.
- Star map texture is now properly displayed in the correct orientation (was previously mirrored).

Additional Notes:
- This deprecates the need for the deep space matrix calculations. Work is pending to properly remove those parts of code no longer needed for this purpose.
- This implementation is not very accurate yet. The sun and moon positions are still relatively incorrect in relation to the sky. This will be addressed in a future update or PR.