### PR TITLE
Star map alignment and better rotation.

### DIFF
--- a/addons/sky_3d/shaders/AtmFog.gdshader
+++ b/addons/sky_3d/shaders/AtmFog.gdshader
@@ -187,6 +187,15 @@ void vertex(){
 
 void fragment(){
 	float depthRaw = texture(DEPTH_TEXTURE, SCREEN_UV).r;
+	
+	#ifndef CURRENT_RENDERER
+	    // For 4.3 or earlier, will break if far plane is less than 1m.
+	    depthRaw = PROJECTION_MATRIX[3][2] > PROJECTION_MATRIX[2][2] ? depthRaw : depthRaw * 2.0 - 1.0;
+    #else
+	    #if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+	    	depthRaw = depthRaw * 2.0 - 1.0;
+	    #endif
+    #endif
 
 	vec3 view; vec3 worldPos;
 	computeCoords(SCREEN_UV, depthRaw, camera_matrix, INV_PROJECTION_MATRIX, view, worldPos);

--- a/addons/sky_3d/shaders/SkyMaterial.gdshader
+++ b/addons/sky_3d/shaders/SkyMaterial.gdshader
@@ -102,7 +102,12 @@ uniform mat3 _moon_matrix; // Set externally via GDScript.
 uniform mat3 _deep_space_matrix; // Set externally via GDScript for star map rotation.
 
 group_uniforms Miscellaneous;
-uniform float _time; // For updating/pausing cloud movement and to work around TIME not working in Compatibility Renderer.
+uniform float _time = 0.0; // For updating/pausing cloud movement and to work around TIME not working in Compatibility Renderer.
+#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+	#define time _time
+#else
+	#define time TIME
+#endif
 
 
 const int kCUMULUS_CLOUDS_STEP = 10;
@@ -169,20 +174,20 @@ bool IntersectSphere(float r, vec3 origin, vec3 dir, out float t, out vec3 nrm)
 	float c = dot(origin, origin) - r * r;
 	float d = b * b - 4.0 * a * c;
 	if(d < 0.0) return false;
-	
+
 	d = sqrt(d);
 	a *= 2.0;
 	float t1 = 0.5 * (-b + d);
 	float t2 = 0.5 * (-b - d);
-	
+
 	if(t1<0.0) t1 = t2;
 	if(t2 < 0.0) t2 = t1;
 	t1 = min(t1, t2);
-	
+
 	if(t1 < 0.0) return false;
 	nrm = origin + t1 * dir;
 	t = t1;
-	
+
 	return true;
 }
 
@@ -268,7 +273,7 @@ vec3 atmosphericScattering(float sr, float sm, vec2 mu, vec3 mult) {
 // Clouds
 //------------------------------------------------------------------------------
 float noiseClouds(vec2 coords, vec2 offset) {
-	float speed = _time * _clouds_speed * .5; // .5 matches cumulus clouds
+	float speed = time * _clouds_speed * .5; // .5 matches cumulus clouds
 	vec2 wind = offset * speed;
 	vec2 wind2 = (offset + offset) * speed;
 	float a = textureLod(_clouds_texture, coords.xy * _clouds_uv - wind, 0.0).r;
@@ -292,11 +297,11 @@ float noiseCloudsCumulus(vec3 p){
 
 float cloudsFBM(vec3 p, float l){
 	float ret;
-	ret = 0.51749673 * noiseCloudsCumulus(p);  
+	ret = 0.51749673 * noiseCloudsCumulus(p);
 	p *= l;
-	ret += 0.25584929 * noiseCloudsCumulus(p); 
-	p *= l; 
-	ret += 0.12527603 * noiseCloudsCumulus(p); 
+	ret += 0.25584929 * noiseCloudsCumulus(p);
+	p *= l;
+	ret += 0.12527603 * noiseCloudsCumulus(p);
 	p *= l;
 	ret += 0.06255931 * noiseCloudsCumulus(p);
 	return ret;
@@ -316,12 +321,12 @@ float cloudsDensityCumulus(vec3 p, vec3 offset, float t){
 	vec3 pos = p * 0.0212242 - offset;
 	float dens = cloudsFBM(pos, _cumulus_clouds_noise_freq);
 	dens += dens;
-	
+
 	float cov = 1.0-_cumulus_clouds_coverage;
 	cov = smoothstep(0.00, (cov * 3.5) + t, dens);
 	dens *= cov;
-	dens = remap(dens, 1.0-cov, 1.0, 0.0, 1.0); 
-	
+	dens = remap(dens, 1.0-cov, 1.0, 0.0, 1.0);
+
 	return saturate(dens);
 }
 
@@ -340,7 +345,7 @@ vec4 renderCloudsCumulus(vec3 ro, vec3 rd, float tm, float am, vec3 sunPosition,
 	vec4 ret = vec4(0, 0, 0, 0);
 	vec3 wind = _cumulus_clouds_direction * (tm * _cumulus_clouds_speed);
 	float a = 0.0;
-	
+
 	// n and tt doesnt need to be initialized since it would be set by IntersectSphere
 	vec3 n; float tt;
     if(IntersectSphere(500, ro, rd, tt, n))
@@ -348,18 +353,18 @@ vec4 renderCloudsCumulus(vec3 ro, vec3 rd, float tm, float am, vec3 sunPosition,
 		float marchStep = float(kCUMULUS_CLOUDS_STEP) * _cumulus_clouds_thickness;
 		vec3 dirStep = rd / rd.y * marchStep;
 		vec3 pos = n * _cumulus_clouds_size;
-		
+
 		vec2 mu = vec2(dot(sunPosition, rd), dot(moonPosition, rd));
 		vec3 mph = ((miePhase(mu.x, _cumulus_clouds_partial_mie_phase) * _atm_sun_mie_tint.rgb) +
 		miePhase(mu.y, _cumulus_clouds_partial_mie_phase) * am);
-		
+
 		vec4 t = vec4(1.0);
 		t.rgb += (mph.rgb * _cumulus_clouds_mie_intensity);
-		
+
 		for(int i = 0; i < kCUMULUS_CLOUDS_STEP; i++)
 		{
 			float h = float(i) * 0.1; // / float(kCLOUDS_STEP);
-			
+
 			float density = cloudsDensityCumulus(pos, wind, h);
 			float sh = saturate(exp(-_cumulus_clouds_absorption * density * marchStep));
 			t *= sh;
@@ -375,7 +380,7 @@ vec4 renderCloudsCumulus(vec3 ro, vec3 rd, float tm, float am, vec3 sunPosition,
 
 vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPosition, vec3 deep_space_coords) {
 	vec3 col = vec3(0.0);
-	
+
 	vec4 angle_mult;
 	angle_mult.x = saturate(1.0 - sunPosition.y);
 	angle_mult.y = saturate(sunPosition.y + 0.45);
@@ -403,10 +408,10 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	float moon_intersect = sphere_intersect(worldPos, moonPosition, _moon_size);
 	float moon_mask = moon_intersect > -0.999 ? 1.0 : 0.0;
 	vec3 moon_normal = normalize(worldPos * moon_intersect - moonPosition);
-	
+
 	float moon_ndotl = clamp(dot(moon_normal, sunPosition), 0.0, 1.0);
 	vec3 moon_texture = get_moon_texture_equirectUV(moon_normal);
-	vec3 moon_output = moon_mask * moon_ndotl * exp2(0.0) * moon_texture;
+	vec3 moon_output = moon_mask * moon_ndotl * exp2(1.0) * moon_texture;
 	float moonMask = (1.0 - moon_mask);
 
 	vec3 deepSpace = vec3(0.0);
@@ -419,7 +424,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	deepSpace.rgb += deepSpaceBackground.rgb * moonMask + moon_output;
 
 	// Stars Field
-	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (_time * _stars_scintillation_speed), 0.0).r;
+	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (time * _stars_scintillation_speed), 0.0).r;
 	starsScintillation = mix(1.0, starsScintillation * 1.5, _stars_scintillation);
 
 	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb * _stars_field_color.rgb;
@@ -439,16 +444,16 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 		clouds.a = mix(0.0, clouds.a, horizonBlend);
 		col.rgb = mix(col.rgb, clouds.rgb + mix(vec3(0.0), scatter, _clouds_sky_tint_fade), clouds.a);
 	}
-	
+
 	if (_cumulus_clouds_visible) {
-		vec4 cumulusClouds = renderCloudsCumulus(vec3(0.0), cloudsPos, _time, angle_mult.z, sunPosition, moonPosition);
+		vec4 cumulusClouds = renderCloudsCumulus(vec3(0.0), cloudsPos, time, angle_mult.z, sunPosition, moonPosition);
 		cumulusClouds.a = saturate(cumulusClouds.a);
-		cumulusClouds.rgb *= mix(mix(_cumulus_clouds_day_color.rgb, _cumulus_clouds_horizon_light_color.rgb, angle_mult.x), 
+		cumulusClouds.rgb *= mix(mix(_cumulus_clouds_day_color.rgb, _cumulus_clouds_horizon_light_color.rgb, angle_mult.x),
 			_cumulus_clouds_night_color.rgb, angle_mult.w);
 		cumulusClouds.a = mix(0.0, cumulusClouds.a, horizonBlend);
 		col.rgb = mix(col.rgb, cumulusClouds.rgb + mix(vec3(0.0), scatter, _cumulus_clouds_sky_tint_fade), cumulusClouds.a);
 	}
-	
+
 	col.rgb = mix(col.rgb, _ground_color.rgb * scatter, saturate((-worldPos.y - _atm_level_params.z) * 100.0));
 	col.rgb = tonemapPhoto(col.rgb, _color_correction_params.y, _color_correction_params.x);
 	col.rgb *= _reflected_energy;
@@ -463,10 +468,10 @@ void sky() {
 	vec3 sunPosition = LIGHT0_DIRECTION; // Redefined from now-deprecated _sun_direction.
 	vec3 moonPosition = LIGHT1_DIRECTION; // Redefined from now-deprecated _moon_direction.
 	vec3 deep_space_coords = (_deep_space_matrix * EYEDIR).xyz;
-	
+
 	if (_sky_visible) {
 		col = render_sky(worldPos, cloudsPos, sunPosition, moonPosition, deep_space_coords);
 	}
-	
+
 	COLOR = col.rgb;
 }

--- a/addons/sky_3d/shaders/SkyMaterial.gdshader
+++ b/addons/sky_3d/shaders/SkyMaterial.gdshader
@@ -58,9 +58,22 @@ uniform vec4 _background_color: source_color = vec4(0.71, 0.71, 0.71, 0.855);
 group_uniforms Starfield;
 uniform vec4 _stars_field_color: source_color = vec4(1.0);
 uniform sampler2D _stars_field_texture: source_color;
+uniform vec3 _sky_alignment = vec3(2.6555, -0.23935, 0.4505);
+uniform float _sky_rotation = 0.0; // For simulating Earth rotation.
+uniform float _sky_tilt = 0.0; // For tilting the sky according to observer latitude in radians. (90° - latitude)
 uniform float _stars_scintillation = 0.75;
 uniform float _stars_scintillation_speed = 0.01;
 uniform sampler2D _noise_tex: source_color;
+
+/* Sky alignment values for a star map that is in galactic coordinates. Works for most star maps.
+X: 2.6555
+Y: -0.23935
+Z: 0.4505
+
+These alignment values are consistent with a sky view from the North Pole (latitude zero)
+at midnight. The positions of Polaris, Vega, Rigel, and Alpha Centauri confirmed
+through various sources and calculations.
+*/
 
 // Clouds
 group_uniforms Clouds;
@@ -136,11 +149,36 @@ vec3 tonemapPhoto(vec3 color, float exposure, float level){
 }
 
 
+// Provides a transformation matrix when passed a vec3.
+mat3 rotationMatrix(vec3 r) {
+    float c1 = cos(r.x), s1 = sin(r.x);
+    float c2 = cos(r.y), s2 = sin(r.y);
+    float c3 = cos(r.z), s3 = sin(r.z);
+
+    mat3 rotX = mat3(
+        vec3(1.0, 0.0, 0.0),
+        vec3(0.0, c1, -s1),
+        vec3(0.0, s1, c1)
+    );
+
+    mat3 rotY = mat3(
+        vec3(c2, 0.0, s2),
+        vec3(0.0, 1.0, 0.0),
+        vec3(-s2, 0.0, c2)
+    );
+
+    mat3 rotZ = mat3(
+        vec3(c3, -s3, 0.0),
+        vec3(s3, c3, 0.0),
+        vec3(0.0, 0.0, 1.0)
+    );
+
+    return rotZ * rotY * rotX; // Combine rotations in ZYX order
+}
+
+
 vec2 equirectUV(vec3 norm) {
-	vec2 ret;
-	ret.x = (atan(norm.x, norm.z) + PI) * (1.0 / TAU);
-	ret.y = acos(norm.y) * (1.0/PI);
-	return ret;
+	return vec2((atan(norm.y, norm.x) + PI) / TAU, acos(norm.z) / -PI);
 }
 
 
@@ -415,7 +453,21 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	float moonMask = (1.0 - moon_mask);
 
 	vec3 deepSpace = vec3(0.0);
-	vec2 deepSpaceUV = equirectUV(normalize(deep_space_coords));
+	
+	// Tilt the sky along the X-axis.
+	mat3 tilt = rotationMatrix(vec3(_sky_tilt, 0.0, 0.0));
+
+    // Rotation around Y-axis. For simulating Earth's rotation.
+    mat3 rotation = rotationMatrix(vec3(0.0, _sky_rotation, 0.0));
+
+    // Initial XYZ rotation for alignment.
+    mat3 alignment_xyz = rotationMatrix(_sky_alignment);
+
+	// Combine everything together to get the desired alignment.
+	vec3 final_alignment = normalize(alignment_xyz * rotation * tilt * worldPos);
+	
+	// Now generate UV coordinates for the texture.
+	vec2 deepSpaceUV = equirectUV(normalize(final_alignment));
 
 	// Background
 	vec3 deepSpaceBackground = textureLod(_background_texture, deepSpaceUV, 0.0).rgb;
@@ -427,7 +479,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 	float starsScintillation = textureLod(_noise_tex, deepSpaceUV + (time * _stars_scintillation_speed), 0.0).r;
 	starsScintillation = mix(1.0, starsScintillation * 1.5, _stars_scintillation);
 
-	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb * _stars_field_color.rgb;
+	vec3 starsField = textureLod(_stars_field_texture, deepSpaceUV, 0.0).rgb;// * _stars_field_color.rgb;
 	starsField = saturateRGB(mix(starsField.rgb, starsField.rgb * starsScintillation, _stars_scintillation));
 	starsField = saturateRGB(starsField.rgb);
 	//deepSpace.rgb -= saturate(starsField.r * 10.0);

--- a/addons/sky_3d/src/Sky3D.gd
+++ b/addons/sky_3d/src/Sky3D.gd
@@ -560,6 +560,9 @@ const MOON_TEXTURE_P: String = "_moon_texture"
 
 # Deep Space
 const DEEP_SPACE_MATRIX_P: String = "_deep_space_matrix"
+const SKY_ALIGNMENT: String = "_sky_alignment"
+const SKY_ROTATION: String = "_sky_rotation"
+const SKY_TILT: String = "_sky_tilt"
 const BG_COL_P: String = "_background_color"
 const BG_TEXTURE_P: String = "_background_texture"
 const STARS_COLOR_P: String = "_stars_field_color"

--- a/addons/sky_3d/src/Skydome.gd
+++ b/addons/sky_3d/src/Skydome.gd
@@ -990,7 +990,8 @@ func update_moon_light_path() -> void:
 #####################
 
 @export_group("Deep Space")
-@export var deep_space_euler: Vector3 = Vector3(0, 0, 0.0): set = set_deep_space_euler
+var deep_space_euler: Vector3 = Vector3(0, 0, 0.0): set = set_deep_space_euler # DEPRECATED
+@export var starmap_alignment: Vector3 = Vector3(2.6555, -0.23935, 0.4505): set = set_starmap_alignment # Default values work for most star maps in galactic coordinate format.
 @export var background_color: Color = Color(0.709804, 0.709804, 0.709804, 0.854902): set = set_background_color
 @export var background_texture: Texture2D = Sky3D._background_texture: set = _set_background_texture
 @export var stars_field_color: Color = Color.WHITE: set = set_stars_field_color
@@ -1000,6 +1001,12 @@ func update_moon_light_path() -> void:
 
 var deep_space_quat: Quaternion = Quaternion.IDENTITY: set = set_deep_space_quat
 var __deep_space_basis: Basis
+
+
+func set_starmap_alignment(value: Vector3) -> void:
+	starmap_alignment = value
+	if sky_material:
+		sky_material.set_shader_parameter(Sky3D.SKY_ALIGNMENT, value)
 
 
 func set_deep_space_euler(value: Vector3) -> void:

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -346,6 +346,7 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0))
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0, __sun_coords.y * TOD_Math.DEG_TO_RAD))
 				__dome.deep_space_quat = x * y
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_TILT, deg_to_rad(90 - latitude))
 		
 		CelestialCalculationsMode.Realistic:
 			__compute_realistic_sun_coords()
@@ -360,10 +361,12 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0) )
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0,  (180.0 - __local_sideral_time * TOD_Math.RAD_TO_DEG) * TOD_Math.DEG_TO_RAD)) 
 				__dome.deep_space_quat = x * y
-	
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_TILT, deg_to_rad(90 - latitude))
+				__dome.sky_material.set_shader_parameter(Sky3D.SKY_ROTATION, __local_sideral_time)
+				
+	__dome.update_moon_coords()
 	if _is_compatibility_mode:
 		__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
-	__dome.update_moon_coords()
 
 
 func __compute_simple_sun_coords() -> void:

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -13,6 +13,7 @@ signal year_changed(value)
 
 var _update_timer: Timer
 var _last_update: int = 0
+var _is_compatibility_mode: bool = false
 
 
 @export var update_in_game: bool = true :
@@ -44,6 +45,8 @@ var _last_update: int = 0
 
 
 func _init() -> void:
+	_is_compatibility_mode = RenderingServer.get_current_rendering_method() == "gl_compatibility"
+		
 	set_total_hours(total_hours)
 	set_day(day)
 	set_month(month)
@@ -357,8 +360,9 @@ func __update_celestial_coords() -> void:
 				var x: Quaternion = Quaternion.from_euler(Vector3( (90 + latitude) * TOD_Math.DEG_TO_RAD, 0.0, 0.0) )
 				var y: Quaternion = Quaternion.from_euler(Vector3(0.0, 0.0,  (180.0 - __local_sideral_time * TOD_Math.RAD_TO_DEG) * TOD_Math.DEG_TO_RAD)) 
 				__dome.deep_space_quat = x * y
-				
-	__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
+	
+	if _is_compatibility_mode:
+		__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
 
 
 func __compute_simple_sun_coords() -> void:

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -363,6 +363,7 @@ func __update_celestial_coords() -> void:
 	
 	if _is_compatibility_mode:
 		__dome.sky_material.set_shader_parameter(Sky3D.SKY_TIME, _last_update / 1000.0)
+	__dome.update_moon_coords()
 
 
 func __compute_simple_sun_coords() -> void:


### PR DESCRIPTION
- Introduced new properties into the shader and GDScript to allow for alignment of star maps. The provided default values work for most star maps in galactic coordinates format and should require little to no adjustment.
  - To-do: Rework the alignment to be more intuitive. Currently it is quite fiddly.
- Introduced properties to the shader and GDScript to directly control sky tilt and rotation for a more intuitive experience.
- Time of day now directly modifies the new sky rotation property and creates a more realistic sky simulation at any latitude. Latitude, Longitude, and UTC settings will also tilt and rotate the sky as expected.
- Star map texture is now properly displayed in the correct orientation (was previously mirrored).

Additional Notes:
- This deprecates the need for the deep space matrix calculations. Work is pending to properly remove those parts of code no longer needed for this purpose.
- This implementation is not very accurate yet. The sun and moon positions are still relatively incorrect in relation to the sky. This will be addressed in a future update or PR.