### PR TITLE
Changed lights_enabled to toggle energy and shadows instead of visibility.

### DIFF
--- a/addons/sky_3d/src/Sky3D.gd
+++ b/addons/sky_3d/src/Sky3D.gd
@@ -67,8 +67,9 @@ func set_lights_enabled(value: bool) -> void:
 	lights_enabled = value
 	if not sky:
 		return
-	sky.__sun_light_node.visible = value
-	sky.__moon_light_node.visible = value
+		
+	sky.sun_light_enabled = value
+	sky.moon_light_enabled = value
 	
 
 ## Enables the screen space fog shader.


### PR DESCRIPTION
- Added two new Booleans in Skydome.gd to control sun and moon light enabled. Instead of setting the node visibility, they will set their respective light energy to zero and turn off shadows.
- Changed the `lights_enabled` property to toggle these new variables.
- Added additional logic for sun and moon lamps to turn their shadows on and off depending on if their energy is above or at zero.